### PR TITLE
Updating install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See the `quickstart.sh` for more detail.
 Once setup, you will need to install the packages for the `WPClothes2Order` plugin.
 
 ```bash
-~/WPClothes2Order-test-env/app/wp-content/plugins/WPClothes2Order$ compose install
+~/WPClothes2Order-test-env/app/wp-content/plugins/WPClothes2Order$ composer install
 ```
 
 ## Development

--- a/install.sh
+++ b/install.sh
@@ -112,5 +112,36 @@ cd wp-content/plugins/$C20_PLUGIN;
 git checkout dev;
 cd ../../../;
 
+# Add ray config
+echo "------------------------------------------------------------------------------------------------------------"
+echo "Adding ray config to app/ray.php";
+echo "------------------------------------------------------------------------------------------------------------"
+tee -a ./ray.php << END
+<?php
+// Save this in a file called "ray.php"
+
+return [
+    /*
+     *  The host used to communicate with the Ray app.
+     */
+    'host' => 'host.docker.internal',
+
+    /*
+     *  The port number used to communicate with the Ray app. 
+     */
+    'port' => 23517,
+    
+    /*
+     *  Absolute base path for your sites or projects in Homestead, Vagrant, Docker, or another remote development server.
+     */
+    'remote_path' => null,
+    
+    /*
+     *  Absolute base path for your sites or projects on your local computer where your IDE or code editor is running on. 
+     */
+    'local_path' => null,
+];
+END
+
 echo "------------------------------------------------------------------------------------------------------------"
 echo "Environment ready.";


### PR DESCRIPTION
WPClothes2Order uses [ray](https://spatie.be/products/ray) for debugging.

However, since the application runs in docker, it needs additional config to work.

This was explained in the issue, [Missing step for using ray](https://github.com/AshleyRedman/WPClothes2Order-test-env/issues/3).

I have also updated the readme to fix the typo of `compose` to `composer`.

To test this I did a fresh install with the new script, did a `composer install` and tested ray:

```
ray("Testing it works");
```

This worked without any additional config.